### PR TITLE
Modify session keys in development.json

### DIFF
--- a/scalecodec/type_registry/development.json
+++ b/scalecodec/type_registry/development.json
@@ -7,8 +7,7 @@
          ["grandpa", "AccountId"],
          ["babe", "AccountId"],
          ["im_online", "AccountId"],
-         ["authority_discovery", "AccountId"],
-         ["parachains", "AccountId"]
+         ["authority_discovery", "AccountId"]
       ]
     },
     "ContractExecResult": "ContractExecResultTo260",


### PR DESCRIPTION
The definition of sessionKeys in the substrate is as follows. The definition in development.json does not match it, so it needs to be modified.

sessionKeys in substrate
https://github.com/paritytech/substrate/blob/48f3cdd8f9720efd488a0f44cf6d923feb17ef03/bin/node/runtime/src/lib.rs#L454
```
pub struct SessionKeys {
	pub grandpa: Grandpa,
	pub babe: Babe,
	pub im_online: ImOnline,
	pub authority_discovery: AuthorityDiscovery,
}
```

sessionKeys in py-scale-codec
https://github.com/polkascan/py-scale-codec/blob/41193d0c69810973a9d0bcce93d2bcae26c1d6a9/scalecodec/type_registry/development.json#L4

```
"Keys": {
  "type": "struct",
  "type_mapping": [
     ["grandpa", "AccountId"],
     ["babe", "AccountId"],
     ["im_online", "AccountId"],
     ["authority_discovery", "AccountId"],
     ["parachains", "AccountId"]
  ]
},
```